### PR TITLE
Add MongoDB Error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,12 @@ actix-web = "2.0"
 derive_more = "0.99"
 dotenv = "0.15"
 
+mongodb = {version = "1.0", optional = true}
+
 
 [lib]
 name = "hcor"
 
 [features]
 actix = []
+mongo = ["mongodb"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ dotenv = "0.15"
 [lib]
 name = "hcor"
 
+[features]
+actix = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ regex = "1.3.6"
 lazy_static = "1.4.0"
 humantime = "2.0.0"
 log = "0.4.8"
+actix-web = "2.0"
+derive_more = "0.99"
 
 [lib]
 name = "hcor"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,9 @@ pub enum ServiceError {
 
     #[display(fmt = "Unauthorized")]
     Unauthorized,
+
+    #[display(fmt = "No data found")]
+    NoData,
 }
 
 #[cfg(feature = "actix")]
@@ -23,6 +26,14 @@ impl ResponseError for ServiceError {
             }
             ServiceError::BadRequest(s) => HttpResponse::BadRequest().body(s),
             ServiceError::Unauthorized => HttpResponse::Unauthorized().body("Unauthorized"),
+            ServiceError::NoData => HttpReponse::NotFound().body("Data not found"),
         }
+    }
+}
+
+#[cfg(feature = "actix")]
+impl From<Box<dyn std::error::Error>> for ServiceError {
+    fn from(_: Box<dyn std::error::Error>) -> ServiceError {
+        ServiceError::InternalServerError
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,24 +4,25 @@ use std::convert::From;
 
 #[derive(Debug, Display)]
 pub enum ServiceError {
-   
-    #[display(fmt="Internal Server Error")]
+    #[display(fmt = "Internal Server Error")]
     InternalServerError,
 
-    #[display(fmt="Bad Request: {}", _0)]
+    #[display(fmt = "Bad Request: {}", _0)]
     BadRequest(String),
 
-    #[display(fmt="Unauthorized")]
+    #[display(fmt = "Unauthorized")]
     Unauthorized,
 }
 
-#[cfg(feature="actix")]
+#[cfg(feature = "actix")]
 impl ResponseError for ServiceError {
     fn error_response(&self) -> HttpResponse {
         match self {
-           ServiceError::InternalServerError => HttpResponse::InternalServerError().body("Internal Server Error. Try again later."),
-           ServiceError::BadRequest(s) => HttpResponse::BadRequest().body(s),
-           ServiceError::Unauthorized => HttpResponse::Unauthorized().body("Unauthorized"),
+            ServiceError::InternalServerError => {
+                HttpResponse::InternalServerError().body("Internal Server Error. Try again later.")
+            }
+            ServiceError::BadRequest(s) => HttpResponse::BadRequest().body(s),
+            ServiceError::Unauthorized => HttpResponse::Unauthorized().body("Unauthorized"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,7 @@ pub enum ServiceError {
     Unauthorized,
 }
 
+#[cfg(feature="actix")]
 impl ResponseError for ServiceError {
     fn error_response(&self) -> HttpResponse {
         match self {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,16 @@
+use actix_web::{error::ResponseError, HttpResponse};
+use derive_more::Display;
+use std::convert::From;
+
+#[derive(Debug, Display)]
+pub enum ServiceError {
+   
+    #[display(fmt="Internal Server Error")]
+    InternalServerError,
+
+    #[display(fmt="Bad Request: {}", _0)]
+    BadRequest(String),
+
+    #[display(fmt="Unauthorized")]
+    Unauthorized,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,3 +14,13 @@ pub enum ServiceError {
     #[display(fmt="Unauthorized")]
     Unauthorized,
 }
+
+impl ResponseError for ServiceError {
+    fn error_response(&self) -> HttpResponse {
+        match self {
+           ServiceError::InternalServerError => HttpResponse::InternalServerError().body("Internal Server Error. Try again later."),
+           ServiceError::BadRequest(s) => HttpResponse::BadRequest().body(s),
+           ServiceError::Unauthorized => HttpResponse::Unauthorized().body("Unauthorized"),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 use actix_web::{error::ResponseError, HttpResponse};
 use derive_more::Display;
 use std::convert::From;
+use mongodb::error::Error as MongoError;
 
 #[derive(Debug, Display)]
 pub enum ServiceError {
@@ -34,6 +35,13 @@ impl ResponseError for ServiceError {
 #[cfg(feature = "actix")]
 impl From<Box<dyn std::error::Error>> for ServiceError {
     fn from(_: Box<dyn std::error::Error>) -> ServiceError {
+        ServiceError::InternalServerError
+    }
+}
+
+#[cfg(feature = "mongo")]
+impl From<MongoError> for ServiceError {
+    fn from(_: MongoError) -> ServiceError {
         ServiceError::InternalServerError
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,15 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::SystemTime;
 
+pub mod errors;
+
 pub mod category;
 pub mod config;
-pub mod errors;
+
 pub mod market;
 pub mod models;
 pub mod possess;
+
 pub mod frontend {
     pub fn emojify<S: ToString>(txt: S) -> String {
         format!(":{}:", txt.to_string().replace(" ", "_"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod market;
 pub mod models;
 pub mod possess;
+pub mod errors;
 pub mod frontend {
     pub fn emojify<S: ToString>(txt: S) -> String {
         format!(":{}:", txt.to_string().replace(" ", "_"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,10 @@ use std::time::SystemTime;
 
 pub mod category;
 pub mod config;
+pub mod errors;
 pub mod market;
 pub mod models;
 pub mod possess;
-pub mod errors;
 pub mod frontend {
     pub fn emojify<S: ToString>(txt: S) -> String {
         format!(":{}:", txt.to_string().replace(" ", "_"))


### PR DESCRIPTION
Allows for conversion from `mongodb::error::Error` to `ServiceError::InternalServerError'